### PR TITLE
Rename branches which contain forward slashes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,7 +116,9 @@ parent-vars:
     - echo ${TRGR_REF}
     - if [ -n "$TRGR_REF" ] && [ "$TRGR_REF" != "master" ]; then
         PR_JSON=`curl -s https://api.github.com/repos/paritytech/ink/pulls/${TRGR_REF}`;
-        UPSTREAM_BRANCH=`echo "${PR_JSON}" | jq -r .head.ref`;
+        # Since we write the branch name to a file we need to remove any forward slashes
+        # which may exist in the name
+        UPSTREAM_BRANCH=`echo "${PR_JSON}" | jq -r .head.ref | sed 's/\//-/'`;
         UPSTREAM_REPO=`echo "${PR_JSON}" | jq -r .head.repo.git_url`;
         UPSTREAM_REPO_NAME=`echo "${PR_JSON}" | jq -r .head.repo.name`;
       fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,7 +118,7 @@ parent-vars:
         PR_JSON=`curl -s https://api.github.com/repos/paritytech/ink/pulls/${TRGR_REF}`;
         # Since we write the branch name to a file we need to remove any forward slashes
         # which may exist in the name
-        UPSTREAM_BRANCH=`echo "${PR_JSON}" | jq -r .head.ref | sed 's/\//-/'`;
+        UPSTREAM_BRANCH=`echo "${PR_JSON}" | jq -r .head.ref | sed 's/\//-/g'`;
         UPSTREAM_REPO=`echo "${PR_JSON}" | jq -r .head.repo.git_url`;
         UPSTREAM_REPO_NAME=`echo "${PR_JSON}" | jq -r .head.repo.name`;
       fi


### PR DESCRIPTION
Looks like Bash isn't happy about file names which contain forward slashes (`/`). You can
try this yourself by running: `echo "foo" | tee bar/foo.txt`.

In order to work around this, I'm proposing that we change all branch names which contain
forward slashes to use hyphens instead.

Closes https://github.com/paritytech/ink-waterfall/issues/11.
