### PR TITLE
Use the original branch name when cloning repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,6 +111,7 @@ parent-vars:
     - |
       # default values
       UPSTREAM_BRANCH="master"
+      UPSTREAM_BRANCH_REDIS_KEY="master"
       UPSTREAM_REPO="https://github.com/paritytech/ink.git"
       UPSTREAM_REPO_NAME="ink"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,19 +117,21 @@ parent-vars:
       echo ${TRGR_REF}
       if [ -n "$TRGR_REF" ] && [ "$TRGR_REF" != "master" ]; then
         PR_JSON=`curl -s https://api.github.com/repos/paritytech/ink/pulls/${TRGR_REF}`;
+        UPSTREAM_BRANCH=`echo "${PR_JSON}" | jq -r .head.ref`;
         # Since we write the branch name to a file we need to remove any forward slashes
         # which may exist in the name
-        UPSTREAM_BRANCH=`echo "${PR_JSON}" | jq -r .head.ref | sed 's/\//-/g'`;
+        UPSTREAM_BRANCH_REDIS_KEY=`echo "${UPSTREAM_BRANCH}" | sed 's/\//-/g'`;
         UPSTREAM_REPO=`echo "${PR_JSON}" | jq -r .head.repo.git_url`;
         UPSTREAM_REPO_NAME=`echo "${PR_JSON}" | jq -r .head.repo.name`;
       fi
     - echo "UPSTREAM_BRANCH=${UPSTREAM_BRANCH}" | tee -a parent-vars.env
+    - echo "UPSTREAM_BRANCH_REDIS_KEY=${UPSTREAM_BRANCH_REDIS_KEY}" | tee -a parent-vars.env
     - echo "UPSTREAM_REPO=${UPSTREAM_REPO}" | tee -a parent-vars.env
     - echo "UPSTREAM_REPO_NAME=${UPSTREAM_REPO_NAME}" | tee -a parent-vars.env
 
     # REDIS_SIZES_KEY (e.g. ink-waterfall::ink::foo-add-feature::sizes)
     # defines a Redis key name where contract sizes will be stored frpm a upstrem above
-    - echo "REDIS_SIZES_KEY=${CI_PROJECT_NAME}::${UPSTREAM_REPO_NAME}::${UPSTREAM_BRANCH}::sizes" | tee -a parent-vars.env
+    - echo "REDIS_SIZES_KEY=${CI_PROJECT_NAME}::${UPSTREAM_REPO_NAME}::${UPSTREAM_BRANCH_REDIS_KEY}::sizes" | tee -a parent-vars.env
 
     # REDIS_SIZES_KEY_MASTER (e.g. ink-waterfall::ink::master::sizes)
     #  defines a Redis key name for a upstream's master reference branch. contracts sizes stored there will be used for


### PR DESCRIPTION
While looking through some `ink!` PRs I realized that that my last re-name fix broke the
`.clone-repo` step (see [these logs](https://gitlab.parity.io/parity/ink-waterfall/-/jobs/1215609)).

This PR will use the original name when cloning the repo, but will use the hypenated name
as a key.
