### PR TITLE
Post contract size diff to parent PR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,8 +187,7 @@ polkadot-js-ui-ink-examples-compare:
   # TODO: While we lack comparison data for master, lets "compare" everything
   # <<:                              *if-trigger-ref-is-master
   script:
-    - apt-get install -y --no-install-recommends jq
-    - jq --version
+    - echo ${TRGR_REF}
     - echo "$REDIS_SIZES_KEY will be compared to $REDIS_SIZES_KEY_MASTER"
     # Deserialize comparison data
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | sort | tee $REDIS_SIZES_KEY.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,7 +163,10 @@ polkadot-js-ui-ink-examples-compare:
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | tee $REDIS_SIZES_KEY.csv
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | tee $REDIS_SIZES_KEY_MASTER.csv
     - echo "Example,Not optimized,Optimized" > contract-size-diff.csv
-    - csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv | sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' | | sed 's/^/`/' | sed 's/,/`,/g' | tee --append contract-size-diff.csv
+    - 'csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
+        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
+        sed 's/^/`/' | sed 's/,/`,/g' |
+        tee --append contract-size-diff.csv'
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
     - cat contract-size-diff.md | sed 's/$/\\n/g' | tr -d '\n' > contract-size-diff-nl.md

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,15 +177,6 @@ polkadot-js-ui-ink-examples:       &polkadot-js-ui-ink-examples
   dependencies:
     - parent-vars
 
-evaluate-ink-examples-size-changes:
-  stage:                           compare-build
-  <<:                              *kubernetes-env
-  <<:                              *vault-secrets
-  # Comparison is made only if a parent (trigger) was created by a PR.
-  # Otherwise we would be comparing `master` with `master`.
-  <<:                              *if-trigger-ref-valid
-  script:
-    - ./scripts/evaluate-examples-size-changes.sh
 
 polkadot-js-ui-rand-extension:
   stage:                           test
@@ -196,6 +187,17 @@ polkadot-js-ui-rand-extension:
     - cargo test --features headless,polkadot-js-ui -- --ignored rand_extension
   after_script:
     - *shutdown-substrate-contracts-node-rand-extension
+
+
+evaluate-ink-examples-size-changes:
+  stage:                           compare-build
+  <<:                              *kubernetes-env
+  <<:                              *vault-secrets
+  # Comparison is made only if a parent (trigger) was created by a PR.
+  # Otherwise we would be comparing `master` with `master`.
+  <<:                              *if-trigger-ref-valid
+  script:
+    - ./.scripts/evaluate-examples-size-changes.sh
 
 
 build_badge:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,7 +194,6 @@ polkadot-js-ui-ink-examples-compare:
         csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
         sort |
         awk -F"," '{printf "`%s`,%.2f kb,%.2f kb\n", $1, $2, $3}' |
-        sed 's/,0.00/,±0.00/g' |
         sed --regexp-extended 's/^([0-9])/,+\1/g' |
         sed --regexp-extended 's/,([0-9])/,+\1/g' |
         tee pure-contract-size-diff.csv
@@ -208,7 +207,7 @@ polkadot-js-ui-ink-examples-compare:
     - paste -d "" pure-contract-size-diff.csv total-optimized-size.csv | tee combined.csv
 
     - echo " ,Δ Original Size,Δ Optimized Size,Total Optimized Size" | tee contract-size-diff.csv
-    - cat combined.csv | tee --append contract-size-diff.csv
+    - cat combined.csv | sed 's/+0.00 kb/‒/g' | tee --append contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv | tee contract-size-diff.md
 
     # Replace `\n` so that it works propely when submitted to the GitHub API.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,10 +163,9 @@ polkadot-js-ui-ink-examples-compare:
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | tee $REDIS_SIZES_KEY.csv
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | tee $REDIS_SIZES_KEY_MASTER.csv
     - echo "Example,Not optimized,Optimized" > contract-size-diff.csv
-    - 'csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
-        sed --regexp-extended "s/[0-9]+\.[0-9]+/& kb/g" |
-        sed "s/^/`/" | sed "s/,/`,/g" |
-        tee --append contract-size-diff.csv'
+    - csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv | \
+        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g\' | sed 's/^/`/' | sed 's/,/`,/' | \
+        tee --append contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
     # Replace new lines and align left

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,7 +81,7 @@ workflow:
 
 .if-trigger-ref-valid:            &if-trigger-ref-valid
   before_script:
-    - if [ "$TRGR_REF" == "master" || -z "$TRGR_REF" ]; then
+    - if [ "$TRGR_REF" == "master" ] || [ -z "$TRGR_REF" ]; then
         echo "It makes no sense to compare $REDIS_SIZES_KEY to $REDIS_SIZES_KEY_MASTER.";
         echo "Exiting gracefully.";
         exit 0;

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,7 +104,7 @@ workflow:
   - pkill -f "substrate-contracts-node-rand-extension --tmp --dev"
 
 
-# needed vars have to be "exported" in a earlier stage
+# Needed vars have to be "exported" in an earlier stage
 parent-vars:
   stage:                                             declare-vars
   <<:                                                *kubernetes-env
@@ -197,7 +197,7 @@ polkadot-js-ui-ink-examples-compare:
         sed 's/^/`/' | sed 's/,/`,/' |
         tee pure-contract-size-diff.csv
 
-    # Append the original optimized size to the end of each line
+    # Append the original optimized size (i.e. not the delta) to the end of each line
     - |
         cat $REDIS_SIZES_KEY.csv |
         egrep --only-matching ', [0-9]+\.[0-9]+$' |
@@ -209,10 +209,13 @@ polkadot-js-ui-ink-examples-compare:
     - cat combined.csv >> contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv | tee contract-size-diff.md
 
-    # Replace new lines and align left
+    # Replace `\n` so that it works propely when submitted to the GitHub API.
+    # Also align the table text left.
     - cat contract-size-diff.md | sed 's/|---/|:---/g' | sed 's/$/\\n/g' | tr -d '\n' | tee contract-size-diff-nl.md
     - COMMENT=$(cat contract-size-diff-nl.md)
 
+    # If there is already a comment by the user `paritytech-ci` in the ink! PR which triggered
+    # this run, then we can just edit this comment (using `PATCH` instead of `POST`).
     - 'COMMENT_URL=$(curl --silent https://api.github.com/repos/paritytech/ink/issues/${TRGR_REF}/comments |
         jq -r ".[] | select(.user.login == \"paritytech-ci\") | .url" | head -n1)'
     - echo $COMMENT_URL
@@ -224,15 +227,14 @@ polkadot-js-ui-ink-examples-compare:
     - echo $VERB
     - echo $COMMENT_URL
     - UPDATED=$(TZ='Europe/Berlin' date)
-    - 'RESP=$(curl -X "${VERB}" "${COMMENT_URL}"
+    - 'curl -X "${VERB}" "${COMMENT_URL}"
         -H "Cookie: logged_in=no"
         -H "Authorization: token ${GITHUB_TOKEN}"
         -H "Content-Type: application/json; charset=utf-8"
         -d $"{
             \"body\": \"## 🦑 📈 Example Contracts ‒ Size Change Report 📉 🦑\\n
             ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\"
-        }")'
-    - echo "api response ${RESP}"
+        }"'
 
 polkadot-js-ui-rand-extension:
   stage:                           test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,7 +193,6 @@ polkadot-js-ui-ink-examples-compare:
     - |
         csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
         sort |
-        xargs -n1 printf "%.2" |
         sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
         sed 's/^/`/' | sed 's/,/`,/' |
         tee pure-contract-size-diff.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -171,7 +171,7 @@ polkadot-js-ui-ink-examples-compare:
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
     # Replace new lines and align left
-    - cat contract-size-diff.md | sed 's/---/:---/g' | sed 's/$/\\n/g' | tr -d '\n' > contract-size-diff-nl.md
+    - cat contract-size-diff.md | sed 's/|---/|:---/g' | sed 's/$/\\n/g' | tr -d '\n' > contract-size-diff-nl.md
     - COMMENT=$(cat contract-size-diff-nl.md)
     - echo $COMMENT
     - TRGR_REF=1015

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -207,12 +207,12 @@ polkadot-js-ui-ink-examples-compare:
     - paste -d "" pure-contract-size-diff.csv total-optimized-size.csv | tee combined.csv
 
     - echo " ,Δ Original Size,Δ Optimized Size,Total Optimized Size" | tee contract-size-diff.csv
-    - cat combined.csv | sed 's/+0.00 kb/‒/g' | tee --append contract-size-diff.csv
+    - cat combined.csv | sed 's/+0.00 kb//g' | tee --append contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv | tee contract-size-diff.md
 
     # Replace `\n` so that it works propely when submitted to the GitHub API.
-    # Also align the table text left.
-    - cat contract-size-diff.md | sed 's/|---/|:---/g' | sed 's/$/\\n/g' | tr -d '\n' | tee contract-size-diff-nl.md
+    # Also align the table text right.
+    - cat contract-size-diff.md | sed 's/---|/---:|/g' | sed 's/$/\\n/g' | tr -d '\n' | tee contract-size-diff-nl.md
     - COMMENT=$(cat contract-size-diff-nl.md)
 
     # If there is already a comment by the user `paritytech-ci` in the ink! PR which triggered

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,9 +79,9 @@ workflow:
     - kubernetes-parity-build
 
 
-.if-trigger-ref-is-master:           &if-trigger-ref-is-master
+.if-trigger-ref-valid:            &if-trigger-ref-valid
   before_script:
-    - if [ "$TRGR_REF" == "master" ]; then
+    - if [ "$TRGR_REF" == "master" || -z "$TRGR_REF" ]; then
         echo "It makes no sense to compare $REDIS_SIZES_KEY to $REDIS_SIZES_KEY_MASTER.";
         echo "Exiting gracefully.";
         exit 0;
@@ -168,7 +168,7 @@ polkadot-js-ui-ink-examples-compare:
   <<:                              *vault-secrets
   # Comparison is made only if a parent (trigger) was created by a PR.
   # Otherwise we would be comparing `master` with `master`.
-  <<:                              *if-trigger-ref-is-master
+  <<:                              *if-trigger-ref-valid
   script:
     - echo ${TRGR_REF}
     - echo "$REDIS_SIZES_KEY will be compared to $REDIS_SIZES_KEY_MASTER"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -203,7 +203,7 @@ polkadot-js-ui-ink-examples-compare:
         -H "Authorization: token ${GITHUB_TOKEN}"
         -H "Content-Type: application/json; charset=utf-8"
         -d $"{
-            \"body\": \"### 🦑 📈 Contract Size Change Report 📉 🦑\\n
+            \"body\": \"### 🦑 📈 Examples Contracts ‒ Size Change Report 📉 🦑\\n
             ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\"
         }")'
     - echo "api response ${RESP}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -182,7 +182,7 @@ polkadot-js-ui-ink-examples-compare:
   <<:                              *kubernetes-env
   <<:                              *vault-secrets
   # Comparison is made only if a parent (trigger) was created by a PR.
-  # Otherwise we would would be comparing `master` with `master`.
+  # Otherwise we would be comparing `master` with `master`.
   <<:                              *if-trigger-ref-is-master
   script:
     - echo ${TRGR_REF}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,10 +172,9 @@ polkadot-js-ui-ink-examples-compare:
     - |
         cat $REDIS_SIZES_KEY.csv |
         egrep --only-matching ', [0-9]+\.[0-9]+$' |
-        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g'
-        > total-optimized-size.csv
-    - cat pure-contract-size-diff.csv
+        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' > total-optimized-size.csv
     - cat total-optimized-size.csv
+    - cat pure-contract-size-diff.csv
     - paste -d "" pure-contract-size-diff.csv total-optimized-size.csv > combined.csv
     - cat combined.csv
     - echo "Example,Δ Original Size,Δ Optimized Size,Total Optimized Size" > contract-size-diff.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -185,63 +185,7 @@ evaluate-ink-examples-size-changes:
   # Otherwise we would be comparing `master` with `master`.
   <<:                              *if-trigger-ref-valid
   script:
-    - echo ${TRGR_REF}
-    - echo "$REDIS_SIZES_KEY will be compared to $REDIS_SIZES_KEY_MASTER"
-    # Deserialize comparison data
-    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | sort | tee $REDIS_SIZES_KEY.csv
-    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | sort | tee $REDIS_SIZES_KEY_MASTER.csv
-    - |
-        csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
-        sort |
-        awk -F"," '{printf "`%s`,%.2f kb,%.2f kb\n", $1, $2, $3}' |
-        sed --regexp-extended 's/^([0-9])/,+\1/g' |
-        sed --regexp-extended 's/,([0-9])/,+\1/g' |
-        tee pure-contract-size-diff.csv
-
-    # Append the original optimized size (i.e. not the delta) to the end of each line
-    - |
-        cat $REDIS_SIZES_KEY.csv | sort | uniq |
-        egrep --only-matching ', [0-9]+\.[0-9]+$' |
-        awk -F", " '{printf ",%.2f kb\n", $2}' |
-        tee total-optimized-size.csv
-    - paste -d "" pure-contract-size-diff.csv total-optimized-size.csv | tee combined.csv
-
-    - echo " ,Δ Original Size,Δ Optimized Size,Total Optimized Size" | tee contract-size-diff.csv
-    - cat combined.csv | sed 's/+0.00 kb//g' | tee --append contract-size-diff.csv
-    - csv2md --pretty < contract-size-diff.csv | tee contract-size-diff.md
-
-    # Replace `\n` so that it works propely when submitted to the GitHub API.
-    # Also align the table text right.
-    - |
-        cat contract-size-diff.md |
-        sed 's/---|/---:|/g' |
-        sed --regexp-extended 's/(-+)\:/:\1/' |
-        sed 's/$/\\n/g' |
-        tr -d '\n' |
-        tee contract-size-diff-nl.md
-    - COMMENT=$(cat contract-size-diff-nl.md)
-
-    # If there is already a comment by the user `paritytech-ci` in the ink! PR which triggered
-    # this run, then we can just edit this comment (using `PATCH` instead of `POST`).
-    - 'COMMENT_URL=$(curl --silent https://api.github.com/repos/paritytech/ink/issues/${TRGR_REF}/comments |
-        jq -r ".[] | select(.user.login == \"paritytech-ci\") | .url" | head -n1)'
-    - echo $COMMENT_URL
-    - VERB="PATCH"
-    - 'if [ -z "$COMMENT_URL" ]; then
-         VERB="POST";
-         COMMENT_URL="https://api.github.com/repos/paritytech/ink/issues/${TRGR_REF}/comments";
-       fi'
-    - echo $VERB
-    - echo $COMMENT_URL
-    - UPDATED=$(TZ='Europe/Berlin' date)
-    - 'curl -X "${VERB}" "${COMMENT_URL}"
-        -H "Cookie: logged_in=no"
-        -H "Authorization: token ${GITHUB_TOKEN}"
-        -H "Content-Type: application/json; charset=utf-8"
-        -d $"{
-            \"body\": \"## 🦑 📈 Example Contracts ‒ Size Change Report 📉 🦑\\n
-            ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\"
-        }"'
+    - ./scripts/evaluate-examples-size-changes.sh
 
 polkadot-js-ui-rand-extension:
   stage:                           test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -189,7 +189,8 @@ polkadot-js-ui-ink-examples-compare:
         -H "Authorization: token ${GITHUB_TOKEN}"
         -H "Content-Type: application/json; charset=utf-8"
         -d $"{
-            \"body\": \"### 🦑 📊 📈 🤖 Contract Size Change Report 🤖 📉 📊 🦑\\n${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}).\n\nLast updated: ${UPDATED}.\"
+            \"body\": \"### 🦑 📊 📈 🤖 Contract Size Change Report 🤖 📉 📊 🦑\\n
+            ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}).\n\nLast updated: ${UPDATED}.\"
         }")'
     - echo "api response ${RESP}"
     - COMMENT_ID=$(echo $RESP | jq -r .id)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,7 @@ polkadot-js-ui-ink-examples-compare:
     - cat pure-contract-size-diff.csv
     - paste -d "" pure-contract-size-diff.csv total-optimized-size.csv > combined.csv
     - cat combined.csv
-    - echo "Example,Δ Original Size,Δ Optimized Size,Total Optimized Size" > contract-size-diff.csv
+    - echo " ,Δ Original Size,Δ Optimized Size,Total Optimized Size" > contract-size-diff.csv
     - cat combined.csv >> contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
@@ -202,7 +202,7 @@ polkadot-js-ui-ink-examples-compare:
         -H "Authorization: token ${GITHUB_TOKEN}"
         -H "Content-Type: application/json; charset=utf-8"
         -d $"{
-            \"body\": \"## 🦑 📈 Examples Contracts ‒ Size Change Report 📉 🦑\\n
+            \"body\": \"## 🦑 📈 Example Contracts ‒ Size Change Report 📉 🦑\\n
             ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\"
         }")'
     - echo "api response ${RESP}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,6 +193,7 @@ polkadot-js-ui-ink-examples-compare:
     - |
         csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
         sort |
+        xargs -n1 printf "%.2" |
         sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
         sed 's/^/`/' | sed 's/,/`,/' |
         tee pure-contract-size-diff.csv
@@ -200,6 +201,7 @@ polkadot-js-ui-ink-examples-compare:
     # Append the original optimized size (i.e. not the delta) to the end of each line
     - |
         cat $REDIS_SIZES_KEY.csv | sort | uniq |
+        xargs -n1 printf "%.2" |
         egrep --only-matching ', [0-9]+\.[0-9]+$' |
         sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
         tee total-optimized-size.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,9 +168,12 @@ polkadot-js-ui-ink-examples-compare:
         sed 's/^/`/' | sed 's/,/`,/' |
         tee pure-contract-size-diff.csv
     # Append the original optimized size to the end of each line
-    - cat $REDIS_SIZES_KEY.csv
     - cat $REDIS_SIZES_KEY.csv | egrep --only-matching ', [0-9]+\.[0-9]+$'
-    - cat $REDIS_SIZES_KEY.csv | egrep --only-matching ', [0-9]+\.[0-9]+$' | > total-optimized-size.csv
+    - |
+        cat $REDIS_SIZES_KEY.csv |
+        egrep --only-matching ', [0-9]+\.[0-9]+$'
+        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
+        > total-optimized-size.csv
     - paste -d "," pure-contract-size-diff.csv total-optimized-size.csv > combined.csv
     - echo "Example,Δ Original Size,Δ Optimized Size,Total Optimized Size" > contract-size-diff.csv
     - cat combined.csv > contract-size-diff.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,11 +160,12 @@ polkadot-js-ui-ink-examples-compare:
     - jq --version
     - echo "$REDIS_SIZES_KEY will be compared to $REDIS_SIZES_KEY_MASTER"
     # Deserialize comparison data
-    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | tee $REDIS_SIZES_KEY.csv
-    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | tee $REDIS_SIZES_KEY_MASTER.csv
+    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' | tee $REDIS_SIZES_KEY.csv
+    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' | tee $REDIS_SIZES_KEY_MASTER.csv
     - echo "Example,Not optimized,Optimized" > contract-size-diff.csv
     - csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv | tee --append contract-size-diff.csv
-    - csv2md < contract-size-diff.csv > contract-size-diff.md
+    - contract-size-diff.csv
+    - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
     - cat contract-size-diff.md | sed 's/$/\\n/g' | tr -d '\n' > contract-size-diff-nl.md
     - COMMENT=$(cat contract-size-diff-nl.md)
@@ -185,7 +186,7 @@ polkadot-js-ui-ink-examples-compare:
         -H "Authorization: token ${GITHUB_TOKEN}"
         -H "Content-Type: application/json; charset=utf-8"
         -d $"{
-            \"body\": \"#### 📊📈 🤖 Did the contract size change?  🤖📉 📊\\n${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}).\"
+            \"body\": \"#### 📊 📈 🤖 Did the contract size change? 🤖 📉 📊\\n${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}).\"
         }")'
     - echo "api response ${RESP}"
     - COMMENT_ID=$(echo $RESP | jq -r .id)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -197,7 +197,11 @@ evaluate-ink-examples-size-changes:
   # Otherwise we would be comparing `master` with `master`.
   <<:                              *if-trigger-ref-valid
   script:
-    - ./.scripts/evaluate-examples-size-changes.sh
+    # Deserialize comparison data
+    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | sort | tee $REDIS_SIZES_KEY.csv
+    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | sort | tee $REDIS_SIZES_KEY_MASTER.csv
+    - PR_COMMENTS_URL=https://api.github.com/repos/paritytech/ink/issues/${TRGR_REF}/comments
+    - ./.scripts/evaluate-examples-size-changes.sh $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv $PR_COMMENTS_URL
 
 
 build_badge:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,7 +104,7 @@ workflow:
   - pkill -f "substrate-contracts-node-rand-extension --tmp --dev"
 
 
-# needed vars have to be "exported" on a earlier stage
+# needed vars have to be "exported" in a earlier stage
 parent-vars:
   stage:                                             declare-vars
   <<:                                                *kubernetes-env
@@ -134,12 +134,12 @@ parent-vars:
     - echo "UPSTREAM_REPO_NAME=${UPSTREAM_REPO_NAME}" | tee -a parent-vars.env
 
     # REDIS_SIZES_KEY (e.g. ink-waterfall::ink::foo-add-feature::sizes)
-    # defines a Redis key name where contract sizes will be stored frpm a upstrem above
+    #   defines a Redis key name where contract sizes will be stored from an upstream above.
     - echo "REDIS_SIZES_KEY=${CI_PROJECT_NAME}::${UPSTREAM_REPO_NAME}::${UPSTREAM_BRANCH_REDIS_KEY}::sizes" | tee -a parent-vars.env
 
     # REDIS_SIZES_KEY_MASTER (e.g. ink-waterfall::ink::master::sizes)
-    #  defines a Redis key name for a upstream's master reference branch. contracts sizes stored there will be used for
-    #  a comparison with contract sizes stored in REDIS_SIZES_KEY
+    #   defines a Redis key name for an upstream's master reference branch.
+    #   contract sizes stored there will be used for a comparison with contract sizes stored in REDIS_SIZES_KEY.
     - echo "REDIS_SIZES_KEY_MASTER=${CI_PROJECT_NAME}::${UPSTREAM_REPO_NAME}::master::sizes" | tee -a parent-vars.env
   artifacts:
     reports:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,7 +169,8 @@ polkadot-js-ui-ink-examples-compare:
         tee pure-contract-size-diff.csv
     # Append the original optimized size to the end of each line
     - cat $REDIS_SIZES_KEY.csv
-    - cat $REDIS_SIZES_KEY.csv | egrep --only-matching ', [0-9]+.[0-9]+$' | > total-optimized-size.csv
+    - cat $REDIS_SIZES_KEY.csv | egrep --only-matching ', [0-9]+\.[0-9]+$'
+    - cat $REDIS_SIZES_KEY.csv | egrep --only-matching ', [0-9]+\.[0-9]+$' | > total-optimized-size.csv
     - paste -d "," pure-contract-size-diff.csv total-optimized-size.csv > combined.csv
     - echo "Example,Δ Original Size,Δ Optimized Size,Total Optimized Size" > contract-size-diff.csv
     - cat combined.csv > contract-size-diff.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,7 +172,7 @@ polkadot-js-ui-ink-examples-compare:
     - |
         cat $REDIS_SIZES_KEY.csv |
         egrep --only-matching ', [0-9]+\.[0-9]+$' |
-        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
+        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g'
         > total-optimized-size.csv
     - cat pure-contract-size-diff.csv
     - cat total-optimized-size.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -162,12 +162,16 @@ polkadot-js-ui-ink-examples-compare:
     # Deserialize comparison data
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | tee $REDIS_SIZES_KEY.csv
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | tee $REDIS_SIZES_KEY_MASTER.csv
-    - echo "Example,Not optimized,Optimized" > contract-size-diff.csv
     - |
         csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
         sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
         sed 's/^/`/' | sed 's/,/`,/' |
-        tee --append contract-size-diff.csv
+        tee pure-contract-size-diff.csv
+    # Append the original optimized size to the end of each line
+    - cat $REDIS_SIZES_KEY.csv | egrep --only-matching ', [0-9]+\.[0-9]+$' | > total-optimized-size.csv
+    - paste -d "," pure-contract-size-diff.csv total-optimized-size.csv > combined.csv
+    - echo "Example,Δ Original Size,Δ Optimized Size,Total Optimized Size" > contract-size-diff.csv
+    - cat combined.csv > contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
     # Replace new lines and align left

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -203,7 +203,7 @@ polkadot-js-ui-ink-examples-compare:
         -H "Authorization: token ${GITHUB_TOKEN}"
         -H "Content-Type: application/json; charset=utf-8"
         -d $"{
-            \"body\": \"### 🦑 📈 Examples Contracts ‒ Size Change Report 📉 🦑\\n
+            \"body\": \"## 🦑 📈 Examples Contracts ‒ Size Change Report 📉 🦑\\n
             ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\"
         }")'
     - echo "api response ${RESP}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,8 +164,8 @@ polkadot-js-ui-ink-examples-compare:
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | tee $REDIS_SIZES_KEY_MASTER.csv
     - echo "Example,Not optimized,Optimized" > contract-size-diff.csv
     - 'csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
-        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
-        sed 's/^/`/' | sed 's/,/`,/g' |
+        sed --regexp-extended "s/[0-9]+\.[0-9]+/& kb/g" |
+        sed "s/^/`/" | sed "s/,/`,/g" |
         tee --append contract-size-diff.csv'
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,6 @@
 
 stages:
   - declare-vars
-  - test
   - compare-build
 
 variables:
@@ -163,20 +162,6 @@ parent-vars:
   - redis-cli -u $GITLAB_REDIS_URI expire $REDIS_SIZES_KEY $GITLAB_REDIS_TTL
 
 
-polkadot-js-ui-ink-examples:       &polkadot-js-ui-ink-examples
-  stage:                           test
-  <<:                              *docker-env
-  <<:                              *vault-secrets
-  script:
-    - *clone-repo
-    - *start-substrate-contracts-node
-    - *build-contracts
-    - WATERFALL_SKIP_CONTRACT_BUILD=true cargo test --jobs 4 --features headless,polkadot-js-ui
-  after_script:
-    - *shutdown-substrate-contracts-node
-  dependencies:
-    - parent-vars
-
 polkadot-js-ui-ink-examples-compare:
   stage:                           compare-build
   <<:                              *kubernetes-env
@@ -235,17 +220,6 @@ polkadot-js-ui-ink-examples-compare:
             \"body\": \"## 🦑 📈 Example Contracts ‒ Size Change Report 📉 🦑\\n
             ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\"
         }"'
-
-polkadot-js-ui-rand-extension:
-  stage:                           test
-  <<:                              *docker-env
-  script:
-    - *clone-repo
-    - *start-substrate-contracts-node-rand-extension
-    - cargo test --features headless,polkadot-js-ui -- --ignored rand_extension
-  after_script:
-    - *shutdown-substrate-contracts-node-rand-extension
-
 
 build_badge:
   stage:                           compare-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,7 +195,7 @@ polkadot-js-ui-ink-examples-compare:
         -H "Authorization: token ${GITHUB_TOKEN}"
         -H "Content-Type: application/json; charset=utf-8"
         -d $"{
-            \"body\": \"### 🦑 📊 📈 🤖 Contract Size Change Report 🤖 📉 📊 🦑\\n
+            \"body\": \"### 🦑 📈 Contract Size Change Report 📉 🦑\\n
             ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\"
         }")'
     - echo "api response ${RESP}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,16 +193,13 @@ polkadot-js-ui-ink-examples-compare:
     - |
         csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
         sort |
-        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
-        sed 's/^/`/' | sed 's/,/`,/' |
+        awk -F", " '{printf "`%s`,%.2f kb,%.2f kb\n", $1, $2, $3}' |
         tee pure-contract-size-diff.csv
 
     # Append the original optimized size (i.e. not the delta) to the end of each line
     - |
         cat $REDIS_SIZES_KEY.csv | sort | uniq |
-        xargs -n1 printf "%.2" |
-        egrep --only-matching ', [0-9]+\.[0-9]+$' |
-        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
+        awk -F", " '{printf "%.2f kb\n", $2}' |
         tee total-optimized-size.csv
     - paste -d "" pure-contract-size-diff.csv total-optimized-size.csv | tee combined.csv
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,7 +163,7 @@ polkadot-js-ui-ink-examples-compare:
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | tee $REDIS_SIZES_KEY.csv
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | tee $REDIS_SIZES_KEY_MASTER.csv
     - echo "Example,Not optimized,Optimized" > contract-size-diff.csv
-    - csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv | sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' | tee --append contract-size-diff.csv
+    - csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv | sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' | | sed 's/^/`/' | sed 's/,/`,/g' | tee --append contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
     - cat contract-size-diff.md | sed 's/$/\\n/g' | tr -d '\n' > contract-size-diff-nl.md
@@ -186,7 +186,7 @@ polkadot-js-ui-ink-examples-compare:
         -H "Authorization: token ${GITHUB_TOKEN}"
         -H "Content-Type: application/json; charset=utf-8"
         -d $"{
-            \"body\": \"#### 🦑 📊 📈 🤖 Did the contract size change? 🤖 📉 📊 🦑\\n${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}).\nLast updated: ${UPDATED}.\"
+            \"body\": \"### 🦑 📊 📈 🤖 Contract Size Change Report 🤖 📉 📊 🦑\\n${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}).\n\nLast updated: ${UPDATED}.\"
         }")'
     - echo "api response ${RESP}"
     - COMMENT_ID=$(echo $RESP | jq -r .id)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@
 
 stages:
   - declare-vars
+  - test
   - compare-build
 
 variables:
@@ -162,6 +163,20 @@ parent-vars:
   - redis-cli -u $GITLAB_REDIS_URI expire $REDIS_SIZES_KEY $GITLAB_REDIS_TTL
 
 
+polkadot-js-ui-ink-examples:       &polkadot-js-ui-ink-examples
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *vault-secrets
+  script:
+    - *clone-repo
+    - *start-substrate-contracts-node
+    - *build-contracts
+    - WATERFALL_SKIP_CONTRACT_BUILD=true cargo test --jobs 4 --features headless,polkadot-js-ui
+  after_script:
+    - *shutdown-substrate-contracts-node
+  dependencies:
+    - parent-vars
+
 polkadot-js-ui-ink-examples-compare:
   stage:                           compare-build
   <<:                              *kubernetes-env
@@ -220,6 +235,17 @@ polkadot-js-ui-ink-examples-compare:
             \"body\": \"## 🦑 📈 Example Contracts ‒ Size Change Report 📉 🦑\\n
             ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\"
         }"'
+
+polkadot-js-ui-rand-extension:
+  stage:                           test
+  <<:                              *docker-env
+  script:
+    - *clone-repo
+    - *start-substrate-contracts-node-rand-extension
+    - cargo test --features headless,polkadot-js-ui -- --ignored rand_extension
+  after_script:
+    - *shutdown-substrate-contracts-node-rand-extension
+
 
 build_badge:
   stage:                           compare-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,10 +160,10 @@ polkadot-js-ui-ink-examples-compare:
     - jq --version
     - echo "$REDIS_SIZES_KEY will be compared to $REDIS_SIZES_KEY_MASTER"
     # Deserialize comparison data
-    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' | tee $REDIS_SIZES_KEY.csv
-    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' | tee $REDIS_SIZES_KEY_MASTER.csv
+    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | tee $REDIS_SIZES_KEY.csv
+    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | tee $REDIS_SIZES_KEY_MASTER.csv
     - echo "Example,Not optimized,Optimized" > contract-size-diff.csv
-    - csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv | tee --append contract-size-diff.csv
+    - csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv | sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' | tee --append contract-size-diff.csv
     - contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
@@ -181,12 +181,13 @@ polkadot-js-ui-ink-examples-compare:
        fi'
     - echo $VERB
     - echo $COMMENT_URL
+    - UPDATED=$(TZ='Europe/Berlin' date)
     - 'RESP=$(curl -X "${VERB}" "${COMMENT_URL}"
         -H "Cookie: logged_in=no"
         -H "Authorization: token ${GITHUB_TOKEN}"
         -H "Content-Type: application/json; charset=utf-8"
         -d $"{
-            \"body\": \"#### 📊 📈 🤖 Did the contract size change? 🤖 📉 📊\\n${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}).\"
+            \"body\": \"#### 📊 📈 🤖 Did the contract size change? 🤖 📉 📊\\n${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}).\nLast updated: ${UPDATED}.\"
         }")'
     - echo "api response ${RESP}"
     - COMMENT_ID=$(echo $RESP | jq -r .id)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,7 +164,6 @@ polkadot-js-ui-ink-examples-compare:
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | tee $REDIS_SIZES_KEY_MASTER.csv
     - echo "Example,Not optimized,Optimized" > contract-size-diff.csv
     - csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv | sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' | tee --append contract-size-diff.csv
-    - contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
     - cat contract-size-diff.md | sed 's/$/\\n/g' | tr -d '\n' > contract-size-diff-nl.md
@@ -187,7 +186,7 @@ polkadot-js-ui-ink-examples-compare:
         -H "Authorization: token ${GITHUB_TOKEN}"
         -H "Content-Type: application/json; charset=utf-8"
         -d $"{
-            \"body\": \"#### 📊 📈 🤖 Did the contract size change? 🤖 📉 📊\\n${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}).\nLast updated: ${UPDATED}.\"
+            \"body\": \"#### 🦑 📊 📈 🤖 Did the contract size change? 🤖 📉 📊 🦑\\n${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}).\nLast updated: ${UPDATED}.\"
         }")'
     - echo "api response ${RESP}"
     - COMMENT_ID=$(echo $RESP | jq -r .id)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,9 +174,12 @@ polkadot-js-ui-ink-examples-compare:
         egrep --only-matching ', [0-9]+\.[0-9]+$'
         sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
         > total-optimized-size.csv
-    - paste -d "," pure-contract-size-diff.csv total-optimized-size.csv > combined.csv
+    - cat pure-contract-size-diff.csv
+    - cat total-optimized-size.csv
+    - paste -d "" pure-contract-size-diff.csv total-optimized-size.csv > combined.csv
+    - cat combined.csv
     - echo "Example,Δ Original Size,Δ Optimized Size,Total Optimized Size" > contract-size-diff.csv
-    - cat combined.csv > contract-size-diff.csv
+    - cat combined.csv >> contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
     # Replace new lines and align left

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -199,6 +199,7 @@ polkadot-js-ui-ink-examples-compare:
     # Append the original optimized size (i.e. not the delta) to the end of each line
     - |
         cat $REDIS_SIZES_KEY.csv | sort | uniq |
+        egrep --only-matching ', [0-9]+\.[0-9]+$' |
         awk -F", " '{printf "%.2f kb\n", $2}' |
         tee total-optimized-size.csv
     - paste -d "" pure-contract-size-diff.csv total-optimized-size.csv | tee combined.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,7 +168,8 @@ polkadot-js-ui-ink-examples-compare:
         sed 's/^/`/' | sed 's/,/`,/' |
         tee pure-contract-size-diff.csv
     # Append the original optimized size to the end of each line
-    - cat $REDIS_SIZES_KEY.csv | egrep --only-matching ', [0-9]+\.[0-9]+$' | > total-optimized-size.csv
+    - cat $REDIS_SIZES_KEY.csv
+    - cat $REDIS_SIZES_KEY.csv | egrep --only-matching ', [0-9]+.[0-9]+$' | > total-optimized-size.csv
     - paste -d "," pure-contract-size-diff.csv total-optimized-size.csv > combined.csv
     - echo "Example,Δ Original Size,Δ Optimized Size,Total Optimized Size" > contract-size-diff.csv
     - cat combined.csv > contract-size-diff.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,10 +160,11 @@ polkadot-js-ui-ink-examples-compare:
     - jq --version
     - echo "$REDIS_SIZES_KEY will be compared to $REDIS_SIZES_KEY_MASTER"
     # Deserialize comparison data
-    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | tee $REDIS_SIZES_KEY.csv
-    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | tee $REDIS_SIZES_KEY_MASTER.csv
+    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | sort | tee $REDIS_SIZES_KEY.csv
+    - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | sort | tee $REDIS_SIZES_KEY_MASTER.csv
     - |
         csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
+        sort |
         sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
         sed 's/^/`/' | sed 's/,/`,/' |
         tee pure-contract-size-diff.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,6 +146,37 @@ parent-vars:
       dotenv: parent-vars.env
 
 
+.build-contracts:                  &build-contracts
+  # delete old list items if the key has existed previously
+  - redis-cli -u $GITLAB_REDIS_URI del $REDIS_SIZES_KEY
+  - echo "Data will be written to $REDIS_SIZES_KEY"
+  - for example in ${INK_EXAMPLES_PATH}/*/; do
+      echo "./.scripts/build-contract.sh ${example} | 
+      redis-cli -u ${GITLAB_REDIS_URI} -x rpush ${REDIS_SIZES_KEY}" >> /tmp/cmds;
+    done
+  - for contract in ${DELEGATOR_SUBCONTRACTS}; do
+      echo "./.scripts/build-contract.sh ${INK_EXAMPLES_PATH}/delegator/${contract} | 
+      redis-cli -u ${GITLAB_REDIS_URI} -x rpush ${REDIS_SIZES_KEY}" >> /tmp/cmds;
+    done
+  - parallel -j 2 < /tmp/cmds
+  # all ci/cd keys need to have ttl
+  - redis-cli -u $GITLAB_REDIS_URI expire $REDIS_SIZES_KEY $GITLAB_REDIS_TTL
+
+
+polkadot-js-ui-ink-examples:       &polkadot-js-ui-ink-examples
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *vault-secrets
+  script:
+    - *clone-repo
+    - *start-substrate-contracts-node
+    - *build-contracts
+    - WATERFALL_SKIP_CONTRACT_BUILD=true cargo test --jobs 4 --features headless,polkadot-js-ui
+  after_script:
+    - *shutdown-substrate-contracts-node
+  dependencies:
+    - parent-vars
+
 polkadot-js-ui-ink-examples-compare:
   stage:                           compare-build
   <<:                              *kubernetes-env
@@ -205,9 +236,16 @@ polkadot-js-ui-ink-examples-compare:
             ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\"
         }")'
     - echo "api response ${RESP}"
-    - COMMENT_ID=$(echo $RESP | jq -r .id)
-    - echo "comment id of created comment ${COMMENT_ID}"
-    - echo ${COMMENT_ID} > comment-id
+
+polkadot-js-ui-rand-extension:
+  stage:                           test
+  <<:                              *docker-env
+  script:
+    - *clone-repo
+    - *start-substrate-contracts-node-rand-extension
+    - cargo test --features headless,polkadot-js-ui -- --ignored rand_extension
+  after_script:
+    - *shutdown-substrate-contracts-node-rand-extension
 
 
 build_badge:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,7 +169,8 @@ polkadot-js-ui-ink-examples-compare:
         tee --append contract-size-diff.csv'
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
-    - cat contract-size-diff.md | sed 's/$/\\n/g' | tr -d '\n' > contract-size-diff-nl.md
+    # Replace new lines and align left
+    - cat contract-size-diff.md | sed 's/---/:---/g' | sed 's/$/\\n/g' | tr -d '\n' > contract-size-diff-nl.md
     - COMMENT=$(cat contract-size-diff-nl.md)
     - echo $COMMENT
     - TRGR_REF=1015

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,7 +193,7 @@ polkadot-js-ui-ink-examples-compare:
     - |
         csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
         sort |
-        awk -F", " '{printf "`%s`,%.2f kb,%.2f kb\n", $1, $2, $3}' |
+        awk -F"," '{printf "`%s`,%.2f kb,%.2f kb\n", $1, $2, $3}' |
         tee pure-contract-size-diff.csv
 
     # Append the original optimized size (i.e. not the delta) to the end of each line

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,7 +163,11 @@ polkadot-js-ui-ink-examples-compare:
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | tee $REDIS_SIZES_KEY.csv
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | tee $REDIS_SIZES_KEY_MASTER.csv
     - echo "Example,Not optimized,Optimized" > contract-size-diff.csv
-    - csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv | sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g\' | sed 's/^/`/' | sed 's/,/`,/' | tee --append contract-size-diff.csv
+    - |
+        csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
+        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
+        sed 's/^/`/' | sed 's/,/`,/' |
+        tee --append contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
     # Replace new lines and align left

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,7 +192,7 @@ polkadot-js-ui-ink-examples-compare:
         -H "Content-Type: application/json; charset=utf-8"
         -d $"{
             \"body\": \"### 🦑 📊 📈 🤖 Contract Size Change Report 🤖 📉 📊 🦑\\n
-            ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}).\n\nLast updated: ${UPDATED}.\"
+            ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\"
         }")'
     - echo "api response ${RESP}"
     - COMMENT_ID=$(echo $RESP | jq -r .id)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,9 +82,9 @@ workflow:
 .if-trigger-ref-is-master:           &if-trigger-ref-is-master
   before_script:
     - if [ "$TRGR_REF" == "master" ]; then
-        echo "It makes no sense to compare $REDIS_SIZES_KEY to $REDIS_SIZES_KEY_MASTER."
-        echo "Exiting gracefully."
-        exit 0
+        echo "It makes no sense to compare $REDIS_SIZES_KEY to $REDIS_SIZES_KEY_MASTER.";
+        echo "Exiting gracefully.";
+        exit 0;
       fi
 
 .clone-repo:                       &clone-repo

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,11 +181,9 @@ polkadot-js-ui-ink-examples-compare:
   stage:                           compare-build
   <<:                              *kubernetes-env
   <<:                              *vault-secrets
-  # Comparison is made only if a parent (trigger) was created on PRs. Otherwise we would
-  # would be comparing `master` with `master`.
-  #
-  # TODO: While we lack comparison data for master, lets "compare" everything
-  # <<:                              *if-trigger-ref-is-master
+  # Comparison is made only if a parent (trigger) was created by a PR.
+  # Otherwise we would would be comparing `master` with `master`.
+  <<:                              *if-trigger-ref-is-master
   script:
     - echo ${TRGR_REF}
     - echo "$REDIS_SIZES_KEY will be compared to $REDIS_SIZES_KEY_MASTER"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -199,7 +199,7 @@ polkadot-js-ui-ink-examples-compare:
 
     # Append the original optimized size (i.e. not the delta) to the end of each line
     - |
-        cat $REDIS_SIZES_KEY.csv |
+        cat $REDIS_SIZES_KEY.csv | sort | uniq |
         egrep --only-matching ', [0-9]+\.[0-9]+$' |
         sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
         tee total-optimized-size.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,7 @@ polkadot-js-ui-ink-examples:       &polkadot-js-ui-ink-examples
   dependencies:
     - parent-vars
 
-polkadot-js-ui-ink-examples-compare:
+evaluate-ink-examples-size-changes:
   stage:                           compare-build
   <<:                              *kubernetes-env
   <<:                              *vault-secrets

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,9 +163,7 @@ polkadot-js-ui-ink-examples-compare:
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | tee $REDIS_SIZES_KEY.csv
     - redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | tee $REDIS_SIZES_KEY_MASTER.csv
     - echo "Example,Not optimized,Optimized" > contract-size-diff.csv
-    - csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv | \
-        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g\' | sed 's/^/`/' | sed 's/,/`,/' | \
-        tee --append contract-size-diff.csv
+    - csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv | sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g\' | sed 's/^/`/' | sed 's/,/`,/' | tee --append contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
     - cat contract-size-diff.md
     # Replace new lines and align left

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,7 +212,13 @@ polkadot-js-ui-ink-examples-compare:
 
     # Replace `\n` so that it works propely when submitted to the GitHub API.
     # Also align the table text right.
-    - cat contract-size-diff.md | sed 's/---|/---:|/g' | sed 's/$/\\n/g' | tr -d '\n' | tee contract-size-diff-nl.md
+    - |
+        cat contract-size-diff.md |
+        sed 's/---|/---:|/g' |
+        sed --regexp-extended 's/(-+)\:/:\1/' |
+        sed 's/$/\\n/g' |
+        tr -d '\n' |
+        tee contract-size-diff-nl.md
     - COMMENT=$(cat contract-size-diff-nl.md)
 
     # If there is already a comment by the user `paritytech-ci` in the ink! PR which triggered

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,25 +168,23 @@ polkadot-js-ui-ink-examples-compare:
         sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
         sed 's/^/`/' | sed 's/,/`,/' |
         tee pure-contract-size-diff.csv
+
     # Append the original optimized size to the end of each line
-    - cat $REDIS_SIZES_KEY.csv | egrep --only-matching ', [0-9]+\.[0-9]+$'
     - |
         cat $REDIS_SIZES_KEY.csv |
         egrep --only-matching ', [0-9]+\.[0-9]+$' |
-        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' > total-optimized-size.csv
-    - cat total-optimized-size.csv
-    - cat pure-contract-size-diff.csv
-    - paste -d "" pure-contract-size-diff.csv total-optimized-size.csv > combined.csv
-    - cat combined.csv
-    - echo " ,Δ Original Size,Δ Optimized Size,Total Optimized Size" > contract-size-diff.csv
+        sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
+        tee total-optimized-size.csv
+    - paste -d "" pure-contract-size-diff.csv total-optimized-size.csv | tee combined.csv
+
+    - echo " ,Δ Original Size,Δ Optimized Size,Total Optimized Size" | tee contract-size-diff.csv
     - cat combined.csv >> contract-size-diff.csv
-    - csv2md --pretty < contract-size-diff.csv > contract-size-diff.md
-    - cat contract-size-diff.md
+    - csv2md --pretty < contract-size-diff.csv | tee contract-size-diff.md
+
     # Replace new lines and align left
-    - cat contract-size-diff.md | sed 's/|---/|:---/g' | sed 's/$/\\n/g' | tr -d '\n' > contract-size-diff-nl.md
+    - cat contract-size-diff.md | sed 's/|---/|:---/g' | sed 's/$/\\n/g' | tr -d '\n' | tee contract-size-diff-nl.md
     - COMMENT=$(cat contract-size-diff-nl.md)
-    - echo $COMMENT
-    - TRGR_REF=1015
+
     - 'COMMENT_URL=$(curl --silent https://api.github.com/repos/paritytech/ink/issues/${TRGR_REF}/comments |
         jq -r ".[] | select(.user.login == \"paritytech-ci\") | .url" | head -n1)'
     - echo $COMMENT_URL

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -200,12 +200,12 @@ polkadot-js-ui-ink-examples-compare:
     - |
         cat $REDIS_SIZES_KEY.csv | sort | uniq |
         egrep --only-matching ', [0-9]+\.[0-9]+$' |
-        awk -F", " '{printf "%.2f kb\n", $2}' |
+        awk -F", " '{printf ",%.2f kb\n", $2}' |
         tee total-optimized-size.csv
     - paste -d "" pure-contract-size-diff.csv total-optimized-size.csv | tee combined.csv
 
     - echo " ,Δ Original Size,Δ Optimized Size,Total Optimized Size" | tee contract-size-diff.csv
-    - cat combined.csv >> contract-size-diff.csv
+    - cat combined.csv | tee --append contract-size-diff.csv
     - csv2md --pretty < contract-size-diff.csv | tee contract-size-diff.md
 
     # Replace `\n` so that it works propely when submitted to the GitHub API.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -171,7 +171,7 @@ polkadot-js-ui-ink-examples-compare:
     - cat $REDIS_SIZES_KEY.csv | egrep --only-matching ', [0-9]+\.[0-9]+$'
     - |
         cat $REDIS_SIZES_KEY.csv |
-        egrep --only-matching ', [0-9]+\.[0-9]+$'
+        egrep --only-matching ', [0-9]+\.[0-9]+$' |
         sed --regexp-extended 's/[0-9]+\.[0-9]+/& kb/g' |
         > total-optimized-size.csv
     - cat pure-contract-size-diff.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,6 +194,9 @@ polkadot-js-ui-ink-examples-compare:
         csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv |
         sort |
         awk -F"," '{printf "`%s`,%.2f kb,%.2f kb\n", $1, $2, $3}' |
+        sed 's/,0.00/,±0.00/g' |
+        sed --regexp-extended 's/^([0-9])/,+\1/g' |
+        sed --regexp-extended 's/,([0-9])/,+\1/g' |
         tee pure-contract-size-diff.csv
 
     # Append the original optimized size (i.e. not the delta) to the end of each line

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -48,10 +48,11 @@ COMMENT=$(cat contract-size-diff-nl.md)
 
 # If there is already a comment by the user `paritytech-ci` in the ink! PR which triggered
 # this run, then we can just edit this comment (using `PATCH` instead of `POST`).
-POSSIBLY_COMMENT_URL=$(curl --silent $PR_URL | \
+POSSIBLY_COMMENT_URL=$(curl --silent $PR_COMMENTS_URL | \
   jq -r ".[] | select(.user.login == \"paritytech-ci\") | .url" | \
   head -n1
 )
+echo $POSSIBLY_COMMENT_URL
 
 VERB="POST"
 if [ ! -z "$POSSIBLY_COMMENT_URL" ]; then

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -18,7 +18,7 @@ echo "$BASELINE_FILE will be compared to $COMPARISON_FILE"
 
 csv-comparator $BASELINE_FILE $COMPARISON_FILE | \
   sort | \
-  awk -F"," '{printf "`%s`,%.2f kb,%.2f kb\n", $1, $2, $3}' | \
+  awk -F"," '{printf "`%s`,%.2f K,%.2f K\n", $1, $2, $3}' | \
   sed --regexp-extended 's/^([0-9])/,+\1/g' | \
   sed --regexp-extended 's/,([0-9])/,+\1/g' | \
   tee pure-contract-size-diff.csv

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -27,7 +27,7 @@ csv-comparator $BASELINE_FILE $COMPARISON_FILE | \
 cat $COMPARISON_FILE | \
   sort | uniq | \
   egrep --only-matching ', [0-9]+\.[0-9]+$' | \
-  awk -F", " '{printf ",%.2f kb\n", $2}' | \
+  awk -F", " '{printf ",%.2f K\n", $2}' | \
   tee total-optimized-size.csv
 
 paste -d "" pure-contract-size-diff.csv total-optimized-size.csv | tee combined.csv

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -61,7 +61,7 @@ curl -X "${VERB}" "${COMMENT_URL}" \
     -H "Cookie: logged_in=no" \
     -H "Authorization: token ${GITHUB_TOKEN}" \
     -H "Content-Type: application/json; charset=utf-8" \
-    -d $"{
-        \"body\": \"## 🦑 📈 Example Contracts ‒ Size Change Report 📉 🦑\\n
-        ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\"
+    -d $"{ \
+        \"body\": \"## 🦑 📈 Example Contracts ‒ Size Change Report 📉 🦑\\n \
+        ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\" \
     }"

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -43,8 +43,8 @@ cat contract-size-diff.md | \
   sed --regexp-extended 's/(-+)\:/:\1/' | \
   sed 's/$/\\n/g' | \
   tr -d '\n' | \
-  tee contract-size-diff-nl.md
-COMMENT=$(cat contract-size-diff-nl.md)
+  tee contract-size-diff-newlines.md
+COMMENT=$(cat contract-size-diff-newlines.md)
 
 # If there is already a comment by the user `paritytech-ci` in the ink! PR which triggered
 # this run, then we can just edit this comment (using `PATCH` instead of `POST`).

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Evaluates size changes of the ink! examples.
+
+set -eux
+echo ${TRGR_REF}
+echo "$REDIS_SIZES_KEY will be compared to $REDIS_SIZES_KEY_MASTER"
+
+# Deserialize comparison data
+redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY 0 -1 | sort | tee $REDIS_SIZES_KEY.csv
+redis-cli -u $GITLAB_REDIS_URI --raw lrange $REDIS_SIZES_KEY_MASTER 0 -1 | sort | tee $REDIS_SIZES_KEY_MASTER.csv
+
+csv-comparator $REDIS_SIZES_KEY_MASTER.csv $REDIS_SIZES_KEY.csv | \
+  sort | \
+  awk -F"," '{printf "`%s`,%.2f kb,%.2f kb\n", $1, $2, $3}' | \
+  sed --regexp-extended 's/^([0-9])/,+\1/g' | \
+  sed --regexp-extended 's/,([0-9])/,+\1/g' | \
+  tee pure-contract-size-diff.csv
+
+# Append the original optimized size (i.e. not the delta) to the end of each line
+cat $REDIS_SIZES_KEY.csv | \
+  sort | uniq | \
+  egrep --only-matching ', [0-9]+\.[0-9]+$' | \
+  awk -F", " '{printf ",%.2f kb\n", $2}' | \
+  tee total-optimized-size.csv
+
+paste -d "" pure-contract-size-diff.csv total-optimized-size.csv | tee combined.csv
+
+echo " ,Δ Original Size,Δ Optimized Size,Total Optimized Size" | tee contract-size-diff.csv
+cat combined.csv | sed 's/+0.00 kb//g' | tee --append contract-size-diff.csv
+csv2md --pretty < contract-size-diff.csv | tee contract-size-diff.md
+
+# Replace `\n` so that it works propely when submitted to the GitHub API.
+# Also align the table text right.
+cat contract-size-diff.md | \
+  sed 's/---|/---:|/g' | \
+  sed --regexp-extended 's/(-+)\:/:\1/' | \
+  sed 's/$/\\n/g' | \
+  tr -d '\n' | \
+  tee contract-size-diff-nl.md
+COMMENT=$(cat contract-size-diff-nl.md)
+
+# If there is already a comment by the user `paritytech-ci` in the ink! PR which triggered
+# this run, then we can just edit this comment (using `PATCH` instead of `POST`).
+COMMENT_URL=$(curl --silent https://api.github.com/repos/paritytech/ink/issues/${TRGR_REF}/comments | \
+  jq -r ".[] | select(.user.login == \"paritytech-ci\") | .url" | \
+  head -n1
+)
+
+echo $COMMENT_URL
+VERB="PATCH"
+
+if [ -z "$COMMENT_URL" ]; then
+   VERB="POST";
+   COMMENT_URL="https://api.github.com/repos/paritytech/ink/issues/${TRGR_REF}/comments";
+fi
+echo $VERB
+echo $COMMENT_URL
+UPDATED=$(TZ='Europe/Berlin' date)
+curl -X "${VERB}" "${COMMENT_URL}" \
+    -H "Cookie: logged_in=no" \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Content-Type: application/json; charset=utf-8" \
+    -d $"{
+        \"body\": \"## 🦑 📈 Example Contracts ‒ Size Change Report 📉 🦑\\n
+        ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\"
+    }"

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -33,7 +33,7 @@ cat $COMPARISON_FILE | \
 paste -d "" pure-contract-size-diff.csv total-optimized-size.csv | tee combined.csv
 
 echo " ,Δ Original Size,Δ Optimized Size,Total Optimized Size" | tee contract-size-diff.csv
-cat combined.csv | sed 's/+0.00 kb//g' | tee --append contract-size-diff.csv
+cat combined.csv | sed 's/+0.00 K//g' | tee --append contract-size-diff.csv
 csv2md --pretty < contract-size-diff.csv | tee contract-size-diff.md
 
 # Replace `\n` so that it works propely when submitted to the GitHub API.

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -19,6 +19,7 @@ echo "$BASELINE_FILE will be compared to $COMPARISON_FILE"
 csv-comparator $BASELINE_FILE $COMPARISON_FILE | \
   sort | \
   awk -F"," '{printf "`%s`,%.2f K,%.2f K\n", $1, $2, $3}' | \
+  # prepend a plus in front of all positive numbers
   sed --regexp-extended 's/^([0-9])/,+\1/g' | \
   sed --regexp-extended 's/,([0-9])/,+\1/g' | \
   tee pure-contract-size-diff.csv

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -62,6 +62,6 @@ curl -X "${VERB}" "${COMMENT_URL}" \
     -H "Authorization: token ${GITHUB_TOKEN}" \
     -H "Content-Type: application/json; charset=utf-8" \
     -d $"{ \
-\"body\": \"## 🦑 📈 Example Contracts ‒ Size Change Report 📉 🦑\\n \
+\"body\": \"## 🦑 📈 ink! Example Contracts ‒ Size Change Report 📉 🦑\\n \
 ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\" \
     }"

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -62,6 +62,6 @@ curl -X "${VERB}" "${COMMENT_URL}" \
     -H "Authorization: token ${GITHUB_TOKEN}" \
     -H "Content-Type: application/json; charset=utf-8" \
     -d $"{ \
-        \"body\": \"## 🦑 📈 Example Contracts ‒ Size Change Report 📉 🦑\\n \
-        ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\" \
+\"body\": \"## 🦑 📈 Example Contracts ‒ Size Change Report 📉 🦑\\n \
+${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\" \
     }"

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -4,8 +4,8 @@
 # as a comment on GitHub.
 #
 # Usage:
-#   ./evaluate-examples-size-changes.sh
-#     <path_to_baseline.csv> <path_to_size_change.csv>
+#   ./evaluate-examples-size-changes.sh \
+#     <path_to_baseline.csv> <path_to_size_change.csv> \
 #     <github_url_to_comments_of_pr>
 
 set -eux

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -64,6 +64,6 @@ curl -X "${VERB}" "${COMMENT_URL}" \
     -H "Content-Type: application/json; charset=utf-8" \
     -d $"{ \
 \"body\": \"## 🦑 📈 ink! Example Contracts ‒ Size Change Report 📉 🦑\\n \
-These are the results of building the \`example/*\` contracts from this branch with \`$CC_VERSION\`. \\n\\n\
+These are the results of building the \`examples/*\` contracts from this branch with \`$CC_VERSION\`. \\n\\n\
 ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\" \
     }"

--- a/.scripts/evaluate-examples-size-changes.sh
+++ b/.scripts/evaluate-examples-size-changes.sh
@@ -57,11 +57,13 @@ fi
 echo $VERB
 echo $COMMENT_URL
 UPDATED=$(TZ='Europe/Berlin' date)
+CC_VERSION=$(cargo-contract --version | egrep --only-matching "cargo-contract [^-]*")
 curl -X "${VERB}" "${COMMENT_URL}" \
     -H "Cookie: logged_in=no" \
     -H "Authorization: token ${GITHUB_TOKEN}" \
     -H "Content-Type: application/json; charset=utf-8" \
     -d $"{ \
 \"body\": \"## 🦑 📈 ink! Example Contracts ‒ Size Change Report 📉 🦑\\n \
+These are the results of building the \`example/*\` contracts from this branch with \`$CC_VERSION\`. \\n\\n\
 ${COMMENT}\n\n[Link to the run](https://gitlab.parity.io/parity/ink-waterfall/-/pipelines/${CI_PIPELINE_ID}) | Last update: ${UPDATED}\" \
     }"


### PR DESCRIPTION
Final step for closing https://github.com/paritytech/ink-waterfall/issues/4 after prior work by @HCastano.

[Example of how it looks](https://github.com/paritytech/ink/pull/1015#issuecomment-968696315).

Ideally we would move the number-formatting stuff into `csv-comparator`, but that can be done in a follow-up if someone feels like it.