### PR TITLE
Add testing for `is_contract` and `is_caller_origin`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,8 +150,12 @@ parent-vars:
   # Copy the local `ink-waterfall` example contracts into `INK_EXAMPLES_PATH`
   # so that they are build and can be tested as well. They'll also show up
   # in the regression bot statistics then.
-  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../.$INK_EXAMPLES_PATH|g" {} \;
+  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../../|g" {} \;
   - cp -r ./examples/* ${INK_EXAMPLES_PATH}
+
+  - cat ./ink/examples/contract-introspection/Cargo.toml
+  - cat ./ink/examples/flipper/Cargo.toml
+
   # delete old list items if the key has existed previously
   - redis-cli -u $GITLAB_REDIS_URI del $REDIS_SIZES_KEY
   - echo "Data will be written to $REDIS_SIZES_KEY"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,10 +152,6 @@ parent-vars:
   # in the regression bot statistics then.
   - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../../|g" {} \;
   - cp -r ./examples/* ${INK_EXAMPLES_PATH}
-
-  - cat ./ink/examples/contract-introspection/Cargo.toml
-  - cat ./ink/examples/flipper/Cargo.toml
-
   # delete old list items if the key has existed previously
   - redis-cli -u $GITLAB_REDIS_URI del $REDIS_SIZES_KEY
   - echo "Data will be written to $REDIS_SIZES_KEY"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,7 +151,7 @@ parent-vars:
   # so that they are build and can be tested as well. They'll also show up
   # in the regression bot statistics then.
   - cp -r ./examples/* ${INK_EXAMPLES_PATH}
-  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../.$INK_EXAMPLES_PATH|g" {} \;
+  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../../.$INK_EXAMPLES_PATH|g" {} \;
   - echo ${INK_EXAMPLES_PATH}
   - cat ./examples/contract-introspection/Cargo.toml
   # delete old list items if the key has existed previously

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,15 +150,8 @@ parent-vars:
   # Copy the local `ink-waterfall` example contracts into `INK_EXAMPLES_PATH`
   # so that they are build and can be tested as well. They'll also show up
   # in the regression bot statistics then.
-  - cp -r ./examples/* ${INK_EXAMPLES_PATH}
-
-  - cat ./examples/contract-introspection/Cargo.toml
   - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../.$INK_EXAMPLES_PATH|g" {} \;
-
-  - echo ${INK_EXAMPLES_PATH}
-  - cat ./ink/examples/contract-introspection/Cargo.toml
-  - cat ./ink/examples/flipper/Cargo.toml
-
+  - cp -r ./examples/* ${INK_EXAMPLES_PATH}
   # delete old list items if the key has existed previously
   - redis-cli -u $GITLAB_REDIS_URI del $REDIS_SIZES_KEY
   - echo "Data will be written to $REDIS_SIZES_KEY"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,7 +151,7 @@ parent-vars:
   # so that they are build and can be tested as well. They'll also show up
   # in the regression bot statistics then.
   - cp -r ./examples/* ${INK_EXAMPLES_PATH}
-  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../../$INK_EXAMPLES_PATH|g" {} \;
+  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../.$INK_EXAMPLES_PATH|g" {} \;
   - echo ${INK_EXAMPLES_PATH}
   - cat ./examples/contract-introspection/Cargo.toml
   # delete old list items if the key has existed previously

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,7 +151,7 @@ parent-vars:
   # so that they are build and can be tested as well. They'll also show up
   # in the regression bot statistics then.
   - cp -r ./examples/* ${INK_EXAMPLES_PATH}
-  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../$INK_EXAMPLES_PATH|g" {} \;
+  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../../$INK_EXAMPLES_PATH|g" {} \;
   # delete old list items if the key has existed previously
   - redis-cli -u $GITLAB_REDIS_URI del $REDIS_SIZES_KEY
   - echo "Data will be written to $REDIS_SIZES_KEY"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,6 +152,8 @@ parent-vars:
   # in the regression bot statistics then.
   - cp -r ./examples/* ${INK_EXAMPLES_PATH}
   - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../../$INK_EXAMPLES_PATH|g" {} \;
+  - echo ${INK_EXAMPLES_PATH}
+  - cat ./examples/contract-introspection/Cargo.toml
   # delete old list items if the key has existed previously
   - redis-cli -u $GITLAB_REDIS_URI del $REDIS_SIZES_KEY
   - echo "Data will be written to $REDIS_SIZES_KEY"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,8 +156,8 @@ parent-vars:
   - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../.$INK_EXAMPLES_PATH|g" {} \;
 
   - echo ${INK_EXAMPLES_PATH}
-  - cat ./examples/contract-introspection/Cargo.toml
-  - cat ./examples/flipper/Cargo.toml
+  - cat ./ink/examples/contract-introspection/Cargo.toml
+  - cat ./ink/examples/flipper/Cargo.toml
 
   # delete old list items if the key has existed previously
   - redis-cli -u $GITLAB_REDIS_URI del $REDIS_SIZES_KEY

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,7 +150,7 @@ parent-vars:
   # Copy the local `ink-waterfall` example contracts into `INK_EXAMPLES_PATH`
   # so that they are build and can be tested as well. They'll also show up
   # in the regression bot statistics then.
-  - cp -r ./examples/ ${INK_EXAMPLES_PATH}
+  - cp -r ./examples/* ${INK_EXAMPLES_PATH}
   - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|$INK_EXAMPLES_PATH|g" {} \;
   # delete old list items if the key has existed previously
   - redis-cli -u $GITLAB_REDIS_URI del $REDIS_SIZES_KEY

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,7 +151,7 @@ parent-vars:
   # so that they are build and can be tested as well. They'll also show up
   # in the regression bot statistics then.
   - cp -r ./examples/* ${INK_EXAMPLES_PATH}
-  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|$INK_EXAMPLES_PATH|g" {} \;
+  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../$INK_EXAMPLES_PATH|g" {} \;
   # delete old list items if the key has existed previously
   - redis-cli -u $GITLAB_REDIS_URI del $REDIS_SIZES_KEY
   - echo "Data will be written to $REDIS_SIZES_KEY"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,9 +151,14 @@ parent-vars:
   # so that they are build and can be tested as well. They'll also show up
   # in the regression bot statistics then.
   - cp -r ./examples/* ${INK_EXAMPLES_PATH}
-  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../../.$INK_EXAMPLES_PATH|g" {} \;
+
+  - cat ./examples/contract-introspection/Cargo.toml
+  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|../.$INK_EXAMPLES_PATH|g" {} \;
+
   - echo ${INK_EXAMPLES_PATH}
   - cat ./examples/contract-introspection/Cargo.toml
+  - cat ./examples/flipper/Cargo.toml
+
   # delete old list items if the key has existed previously
   - redis-cli -u $GITLAB_REDIS_URI del $REDIS_SIZES_KEY
   - echo "Data will be written to $REDIS_SIZES_KEY"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,6 +158,11 @@ parent-vars:
 
 .build-ink-example-contracts:                  &build-ink-example-contracts
   - set -o pipefail
+  # Copy the local `ink-waterfall` example contracts into `INK_EXAMPLES_PATH`
+  # so that they are build and can be tested as well. They'll also show up
+  # in the regression bot statistics then.
+  - cp -r ./examples/ ${INK_EXAMPLES_PATH}
+  - find ./examples/ -name 'Cargo.toml' -exec sed -i "s|../ink|$INK_EXAMPLES_PATH|g" {} \;
   # delete old list items if the key has existed previously
   - redis-cli -u $GITLAB_REDIS_URI del $REDIS_SIZES_KEY
   - echo "Data will be written to $REDIS_SIZES_KEY"

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ supply `--features polkadot-js-ui` to `cargo test`.
 
 * `INK_EXAMPLES_PATH` ‒ Path to the ink! examples folder. Must be set.
 * `UI_URL` ‒ URL of the UI to use. Defaults to the live interface for the chosen UI.
-* `WATERFALL_CLOSE_BROWSER` ‒ Do not close browser window at the end of a test run.
-  Defaults to `true`. Set it to `false` to prevent closing .
+* `WATERFALL_CLOSE_BROWSER` ‒ Close browser window at the end of a test run.
+  Defaults to `true`. Set it to `false` to prevent closing.
 * `WATERFALL_SKIP_CONTRACT_BUILD` ‒ Do not build the contracts, re-use existing artifacts
   from their `target` folder. Defaults to `false`. Set it to `true` to skip building.
 * `NODE_PORT` ‒ Port under which the `substrate-contracts-node` is running. Defaults to `9944`.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ requirement. By default the published versions of those projects are used
 ## Run it locally
 
 ```bash
+# Create a link to ink! in the local examples of the `ink-waterfall`.
+ln -s /path/to/ink/ ./examples/ink
+
 export INK_EXAMPLES_PATH=/path/to/ink/examples/
 substrate-contracts-node --tmp --dev > /tmp/substrate-contracts-node.log 2>&1 &
 

--- a/examples/contract-introspection/.gitignore
+++ b/examples/contract-introspection/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/examples/contract-introspection/Cargo.toml
+++ b/examples/contract-introspection/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "contract_introspection"
+version = "3.0.0-rc9"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+
+[dependencies]
+ink_primitives = { path = "../ink/crates/primitives", default-features = false }
+ink_metadata = { path = "../ink/crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../ink/crates/env", default-features = false }
+ink_storage = { path = "../ink/crates/storage", default-features = false }
+ink_lang = { path = "../ink/crates/lang", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+
+[lib]
+name = "contract_introspection"
+path = "lib.rs"
+crate-type = ["cdylib"]
+
+[features]
+default = ["std"]
+std = [
+    "ink_primitives/std",
+    "ink_metadata/std",
+    "ink_env/std",
+    "ink_storage/std",
+    "ink_lang/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []
+
+[workspace]

--- a/examples/contract-introspection/lib.rs
+++ b/examples/contract-introspection/lib.rs
@@ -1,0 +1,65 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use ink_lang as ink;
+
+#[ink::contract]
+mod contract_introspection {
+    use ink_env::{
+        call::{
+            build_call,
+            utils::ReturnType,
+            ExecutionInput,
+            Selector,
+        },
+        CallFlags,
+        DefaultEnvironment,
+    };
+
+    #[ink(storage)]
+    pub struct ContractInspection {}
+
+    impl ContractInspection {
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self {}
+        }
+
+        /// Returns `true` if the caller is a contract.
+        #[ink(message, selector = 1)]
+        pub fn is_caller_contract(&self) -> bool {
+            self.env().is_contract(&self.env().caller())
+        }
+
+        /// Returns `true` if the caller is the origin of this call.
+        #[ink(message, selector = 2)]
+        pub fn is_caller_origin(&self) -> bool {
+            self.env().caller_is_origin()
+        }
+
+        /// Calls into this contract to the [`is_caller_contract`] function
+        /// and returns the return value of that function.
+        #[ink(message)]
+        pub fn calls_is_caller_contract(&self) -> bool {
+            build_call::<DefaultEnvironment>()
+                .callee(self.env().account_id())
+                .exec_input(ExecutionInput::new(Selector::new([0x00, 0x00, 0x00, 0x01])))
+                .returns::<ReturnType<bool>>()
+                .call_flags(CallFlags::default().set_allow_reentry(true))
+                .fire()
+                .expect("failed executing call")
+        }
+
+        /// Calls into this contract to the [`is_caller_origin`] function
+        /// and returns the return value of that function.
+        #[ink(message)]
+        pub fn calls_is_caller_origin(&self) -> bool {
+            build_call::<DefaultEnvironment>()
+                .callee(self.env().account_id())
+                .exec_input(ExecutionInput::new(Selector::new([0x00, 0x00, 0x00, 0x02])))
+                .returns::<ReturnType<bool>>()
+                .call_flags(CallFlags::default().set_allow_reentry(true))
+                .fire()
+                .expect("failed executing call")
+        }
+    }
+}

--- a/src/tests/contract_introspection.rs
+++ b/src/tests/contract_introspection.rs
@@ -1,0 +1,68 @@
+// Copyright 2018-2021 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the `contract_introspection `example.
+
+use crate::{
+    uis::{
+        Call,
+        Result,
+        Ui,
+        Upload,
+    },
+    utils::{
+        self,
+        cargo_contract,
+    },
+};
+use lang_macro::waterfall_test;
+
+#[waterfall_test(example = "contract_introspection")]
+async fn delegator_works(mut ui: Ui) -> Result<()> {
+    // given
+    let contract_path =
+        cargo_contract::build(&utils::example_path("contract-introspection/Cargo.toml"))
+            .expect("contract build failed");
+
+    // when
+    let addr = ui.execute_upload(Upload::new(contract_path)).await?;
+
+    // then
+    // the method is called directly via the ui.
+    assert_eq!(
+        ui.execute_rpc(Call::new(&addr, "is_caller_contract"))
+            .await?,
+        "false"
+    );
+    // the `is_caller_contract` method is called indirectly from this contract method.
+    assert_eq!(
+        ui.execute_rpc(Call::new(&addr, "calls_is_caller_contract"))
+            .await?,
+        "true"
+    );
+
+    // the method is called directly via the ui.
+    assert_eq!(
+        ui.execute_rpc(Call::new(&addr, "is_caller_origin")).await?,
+        "true"
+    );
+    // the `is_caller_origin` method is called indirectly from this contract method.
+    assert_eq!(
+        ui.execute_rpc(Call::new(&addr, "calls_is_caller_origin"))
+            .await?,
+        "false"
+    );
+
+    Ok(())
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod contract_introspection;
 mod contract_terminate;
 mod contract_transfer;
 mod delegator;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -38,6 +38,8 @@ pub fn example_path(example: &str) -> PathBuf {
     let mut path = PathBuf::from(examples_path).join(example);
 
     // Check if path exists, if not assume it's a local example to `ink-waterfall`.
+    // This is done as a fallback if the waterfall tests are run locally.
+    // For the CI we copy all `ink-waterfall/examples/` to the `INK_EXAMPLES_PATH`.
     if !path.exists() {
         path = PathBuf::from("./examples/").join(example);
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -29,11 +29,20 @@ pub fn test_name() -> String {
 }
 
 /// Returns the full path to the ink! example directory for `example`.
+///
+/// This method will first try to look the example up in `INK_EXAMPLES_PATH`.
+/// If not found there, it will fall back to `./examples/` ++ `example`.
 pub fn example_path(example: &str) -> PathBuf {
     let examples_path = std::env::var("INK_EXAMPLES_PATH")
         .expect("env variable `INK_EXAMPLES_PATH` must be set");
-    let path = PathBuf::from(examples_path);
-    path.join(example)
+    let mut path = PathBuf::from(examples_path).join(example);
+
+    // Check if path exists, if not assume it's a local example to `ink-waterfall`.
+    if !path.exists() {
+        path = PathBuf::from("./examples/").join(example);
+    }
+
+    path
 }
 
 /// Extracts the `source.hash` field from the contract bundle.


### PR DESCRIPTION
@athei @agryaznov I've added an example contract to the `ink-waterfall` which will run as part of the CI ‒ thus demonstrating that `is_contract` and `is_caller_origin` work as intended. Do you think we can now stabilize those two methods in `pallet-contracts`?