### PR TITLE
Remove `--tmp` and `--dev` flags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,16 +94,16 @@ workflow:
     fi
 
 .start-substrate-contracts-node:                     &start-substrate-contracts-node
-  - substrate-contracts-node --dev -lruntime::contracts=debug > /tmp/substrate-contracts-node.log 2>&1 &
+  - substrate-contracts-node -lruntime::contracts=debug > /tmp/substrate-contracts-node.log 2>&1 &
 
 .start-substrate-contracts-node-rand-extension:      &start-substrate-contracts-node-rand-extension
-  - substrate-contracts-node-rand-extension --dev -lruntime::contracts=debug > /tmp/substrate-contracts-node-rand-extension.log 2>&1 &
+  - substrate-contracts-node-rand-extension -lruntime::contracts=debug > /tmp/substrate-contracts-node-rand-extension.log 2>&1 &
 
 .shutdown-substrate-contracts-node:                  &shutdown-substrate-contracts-node
-  - pkill -f "substrate-contracts-node --dev"
+  - pkill -f "substrate-contracts-node"
 
 .shutdown-substrate-contracts-node-rand-extension:   &shutdown-substrate-contracts-node-rand-extension
-  - pkill -f "substrate-contracts-node-rand-extension --dev"
+  - pkill -f "substrate-contracts-node-rand-extension"
 
 
 # Needed vars have to be "exported" in an earlier stage

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ requirement. By default the published versions of those projects are used
 ln -s /path/to/ink/ ./examples/ink
 
 export INK_EXAMPLES_PATH=/path/to/ink/integration-tests/
-substrate-contracts-node --tmp --dev > /tmp/substrate-contracts-node.log 2>&1 &
+substrate-contracts-node > /tmp/substrate-contracts-node.log 2>&1 &
 
 # By default you will see the Firefox GUI and the
 # tests interacting with it.


### PR DESCRIPTION
These are enabled by default for the latests
`substrate-contracts-node` releases.
