### PR TITLE
Adding gitspiegel-trigger workflow

### DIFF
--- a/.github/workflows/gitspiegel-trigger.yml
+++ b/.github/workflows/gitspiegel-trigger.yml
@@ -1,0 +1,20 @@
+name: gitspiegel sync
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - unlocked
+      - ready_for_review
+      - reopened
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sync via API
+        run: |
+          curl --fail-with-body -XPOST "https://gitspiegel.parity-prod.parity.io/api/v1/mirror/${{ github.repository }}/pull/${{ github.event.number }}" \
+           -H "Content-Type: application/json" \
+           -H "x-auth: ${{ secrets.GITSPIEGEL_TOKEN }}"

--- a/.github/workflows/gitspiegel-trigger.yml
+++ b/.github/workflows/gitspiegel-trigger.yml
@@ -1,5 +1,10 @@
 name: gitspiegel sync
 
+# This workflow doesn't do anything, it's only use is to trigger "workflow_run"
+# webhook, that'll be consumed by gitspiegel
+# This way, gitspiegel won't do mirroring, unless this workflow runs,
+# and running the workflow is protected by GitHub
+
 on:
   pull_request:
     types:
@@ -13,8 +18,5 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger sync via API
-        run: |
-          curl --fail-with-body -XPOST "https://gitspiegel.parity-prod.parity.io/api/v1/mirror/${{ github.repository }}/pull/${{ github.event.number }}" \
-           -H "Content-Type: application/json" \
-           -H "x-auth: ${{ secrets.GITSPIEGEL_TOKEN }}"
+      - name: Do nothing
+        run: echo "let's go"


### PR DESCRIPTION
Using a workflow to trigger mirroring instead of a webhook allows us to reuse "Approving workflow runs from public forks" GitHub feature to somewhat protect us from malicious PRs